### PR TITLE
Ignore helptags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 addon-info.json
+doc/tags


### PR DESCRIPTION
Helptags should be generated by vim, but aren't provided, so they should
be ignored to prevent constant "untracked files" errors/warnings.

Maybe this is only irritating to me since I used submodules to organize my .vim folder, but it's also a simple fix.